### PR TITLE
Line 10 needed to be tab to compile on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ svg2gcode:	svg2gcode.c nanosvg.h
 	$(CC) -o svg2gcode -g svg2gcode.c -lm
 
 clean:
-  rm -fr svg2code *.o
-  
+	rm -fr svg2code *.o
+


### PR DESCRIPTION
Line 7 starts with a tab character, line 10 starts with two spaces.

<img width="359" alt="screen shot 2015-12-11 at 2 50 44 pm" src="https://cloud.githubusercontent.com/assets/3356993/11754032/c27e8514-a016-11e5-9888-00a76c88ee7c.png">

<img width="404" alt="screen shot 2015-12-11 at 2 51 33 pm" src="https://cloud.githubusercontent.com/assets/3356993/11754047/ddb189f8-a016-11e5-9ef6-f59999f711b5.png">
